### PR TITLE
Use Git Tags as additional Docker Image Tags

### DIFF
--- a/.github/docker/Dockerfile
+++ b/.github/docker/Dockerfile
@@ -1,0 +1,3 @@
+FROM alpine:3.10.3
+
+ENTRYPOINT ["echo", "'hello world'"]

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -20,7 +20,7 @@ jobs:
           IMAGE_TAG: 'v0.0'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: './'
-      - name: Build and Publish Docker image in GPR
+      - name: Build and Publish Docker image to Dockerhub instead of GPR
         uses: saubermacherag/gpr-docker-publish@master
         with:
           USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
@@ -28,4 +28,4 @@ jobs:
           IMAGE_TAG: 'v0.0'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: './'
-          DOCKERHUB_REPOSITORY: 'pinkrobin/docker-ansible-alpine'
+          DOCKERHUB_REPOSITORY: 'pinkrobin/gpr-docker-publish-example'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,0 +1,22 @@
+name: Test Docker Image Creation
+
+on: [push]
+
+jobs:
+
+  build:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v1
+        with:
+          fetch-depth: 1
+      - name: Build and Publish Docker image
+        uses: saubermacherag/gpr-docker-publish@master
+        with:
+          USERNAME: x-access-token
+          PASSWORD: ${{ secrets.GITHUB_TOKEN }}
+          IMAGE_NAME: 'gpr-docker-publish-test'
+          IMAGE_TAG: 'v0.0'
+          DOCKERFILE_PATH: '.github/docker/Dockerfile'
+          BUILD_CONTEXT: './'

--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -11,7 +11,7 @@ jobs:
         uses: actions/checkout@v1
         with:
           fetch-depth: 1
-      - name: Build and Publish Docker image
+      - name: Build and Publish Docker image in GPR
         uses: saubermacherag/gpr-docker-publish@master
         with:
           USERNAME: x-access-token
@@ -20,3 +20,12 @@ jobs:
           IMAGE_TAG: 'v0.0'
           DOCKERFILE_PATH: '.github/docker/Dockerfile'
           BUILD_CONTEXT: './'
+      - name: Build and Publish Docker image in GPR
+        uses: saubermacherag/gpr-docker-publish@master
+        with:
+          USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+          PASSWORD: ${{ secrets.DOCKERHUB_PAT }}
+          IMAGE_TAG: 'v0.0'
+          DOCKERFILE_PATH: '.github/docker/Dockerfile'
+          BUILD_CONTEXT: './'
+          DOCKERHUB_REPOSITORY: 'pinkrobin/docker-ansible-alpine'

--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+# Created by .ignore support plugin (hsz.mobi)
+.idea

--- a/README.md
+++ b/README.md
@@ -59,6 +59,17 @@ jobs:
         DOCKERFILE_PATH: 'argo/gpu.Dockerfile'
         BUILD_CONTEXT: 'argo/'
 
+    #To access another docker registry like dockerhub you'll have to add `DOCKERHUB_UERNAME` and `DOCKERHUB_PAT` in github secrets.
+    - name: Build and Publish Docker image to Dockerhub instead of GPR
+      uses: saubermacherag/gpr-docker-publish@master
+      with:
+        USERNAME: ${{ secrets.DOCKERHUB_USERNAME }}
+        PASSWORD: ${{ secrets.DOCKERHUB_PAT }}
+        IMAGE_TAG: 'v0.0'
+        DOCKERFILE_PATH: '.github/docker/Dockerfile'
+        BUILD_CONTEXT: './'
+        DOCKERHUB_REPOSITORY: 'pinkrobin/gpr-docker-publish-example'
+
     # This second step is illustrative and shows how to reference the 
     # output variables.  This is completely optional.
     - name: Show outputs of pervious step

--- a/README.md
+++ b/README.md
@@ -82,6 +82,8 @@ jobs:
 
 1. `cache`: if value is `true`, attempts to use the last pushed image as a cache.  Default value is `false`.
 2. `IMAGE_TAG`: if value is set, use provided value.  Default value is the first 12 characters of the GitHub SHA that triggered the action.
+3. `DOCKERHUB_REPOSITORY`: if value is set, you don't need to set `IMAGE_NAME`. It will push the image to the given dockerhub repository instead of using GPR.
+Why? Because Github Actions don't support downloading images without authentication at the moment. See: https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/m-p/32782
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -26,6 +26,9 @@ Where:
 - `Image_Name` is provided by the user as an input.
 - `IMAGE_TAG` is either the first 12 characters of the GitHub commit SHA or the value of INPUT_IMAGE_TAG env variable
 
+Additionally it will use Git Tags pointing to the HEAD commit to create docker tags accordingly. 
+E.g. Git Tag v1.1 will result in an additional docker tag v1.1.
+
 ## Usage
 
 
@@ -52,6 +55,7 @@ jobs:
         USERNAME: ${{ secrets.DOCKER_USERNAME }}
         PASSWORD: ${{ secrets.DOCKER_PASSWORD }}
         IMAGE_NAME: 'test-docker-action'
+        IMAGE_TAG: 'v0.0'
         DOCKERFILE_PATH: 'argo/gpu.Dockerfile'
         BUILD_CONTEXT: 'argo/'
 
@@ -68,8 +72,8 @@ jobs:
 
 ### Mandatory Inputs
 
-1. `USERNAME` the login username, most likely your github handle.  This username must have write access to the repo where the action is called.
-2. `PASSWORD` Your GitHub password that has write access to the repo where this action is called.
+1. `USERNAME` the login username, most likely your github handle.  This username must have write access to the repo where the action is called. `x-access-token` should suffice.
+2. `PASSWORD` Your GitHub password that has write access to the repo where this action is called. `${{ secrets.GITHUB_TOKEN }}` should suffice.
 3. `IMAGE_NAME` is the name of the image you would like to push  
 4. `DOCKERFILE_PATH`: The full path (including the filename) relative to the root of the repository that contains the Dockerfile that specifies your build.
 5. `BUILD_CONTEXT`: The directory for the build context.  See these [docs](https://docs.docker.com/engine/reference/commandline/build/) for more information on the definition of build context.

--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@ This Action will automatically tag each image as follows:
 
 Where:
 - `Image_Name` is provided by the user as an input.
-- `shortSHA` is the first 12 characters of the GitHub SHA that triggered the action.
+- `shortSHA` is either the first 12 characters of the GitHub commit SHA or the value of IMAGE_TAG env variable
 
 ## Usage
 
@@ -77,6 +77,7 @@ jobs:
 ## Optional Inputs
 
 1. `cache`: if value is `true`, attempts to use the last pushed image as a cache.  Default value is `false`.
+2. `IMAGE_TAG`: if value is set, use provided value.  Default value is the first 12 characters of the GitHub SHA that triggered the action.
 
 ## Outputs
 

--- a/README.md
+++ b/README.md
@@ -20,11 +20,11 @@ The GitHub Package Registry allows you to develop your code and host your packag
 
 This Action will automatically tag each image as follows:
 
-    {Image_Name}:{shortSHA}
+    {Image_Name}:{IMAGE_TAG}
 
 Where:
 - `Image_Name` is provided by the user as an input.
-- `shortSHA` is either the first 12 characters of the GitHub commit SHA or the value of IMAGE_TAG env variable
+- `IMAGE_TAG` is either the first 12 characters of the GitHub commit SHA or the value of INPUT_IMAGE_TAG env variable
 
 ## Usage
 
@@ -83,7 +83,7 @@ jobs:
 
 You can reference the outputs of an action using [expression syntax](https://help.github.com/en/articles/contexts-and-expression-syntax-for-github-actions), as illustrated in the Example Pipeline above.
 
-1. `IMAGE_SHA_NAME`: This is the `{Image_Name}:{shortSHA}` as described above.
+1. `IMAGE_SHA_NAME`: This is the `{Image_Name}:{IMAGE_TAG}` as described above.
 2. `IMAGE_URL`: This is the URL on GitHub where you can view your hosted Docker images.  This will always be located at `https://github.com/{OWNER}/{REPOSITORY}/packages` in reference to the repository where the action was called.
 
 These outputs are merely provided as convenience incase you want to use these values in subsequent steps.

--- a/action.yaml
+++ b/action.yaml
@@ -26,6 +26,9 @@ inputs:
   image_tag:
     description: Optional input to set a tag name instead of a hash.
     required: false
+  dockerhub_repository:
+    description: Optional input to push image to dockerhub repository instead of GPR.
+    required: false
 outputs:
   IMAGE_SHA_NAME:
     description: name of the Docker Image including the tag

--- a/action.yaml
+++ b/action.yaml
@@ -10,19 +10,22 @@ inputs:
     require: true
   image_name:
     description: name of the image.  Example - myContainer
-    require: true
+    required: true
   build_context:
     description: the path in your repo that will serve as the build context
-    require: true
+    required: true
     default: './'
   dockerfile_path:
     description: the full path (including the filename) to the dockerfile that you want to build
-    require: true
+    required: true
     default: ./Dockerfile
   cache:
     description: attempt to use last image as the cache
-    require: false
+    required: false
     default: false
+  image_tag:
+    description: Optional input to set a tag name instead of a hash.
+    required: false
 outputs:
   IMAGE_SHA_NAME:
     description: name of the Docker Image including the tag

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -33,9 +33,9 @@ if [[ -z "$INPUT_BUILD_CONTEXT" ]]; then
 fi
 
 if [[ -z "$INPUT_IMAGE_TAG" ]]; then
-	shortSHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
+	IMAGE_TAG=$(echo "${GITHUB_SHA}" | cut -c1-12)
 else
-	shortSHA=$INPUT_IMAGE_TAG
+	IMAGE_TAG=$INPUT_IMAGE_TAG
 fi
 
 # The following environment variables will be provided by the environment automatically: GITHUB_REPOSITORY, GITHUB_SHA
@@ -45,7 +45,7 @@ echo ${INPUT_PASSWORD} | docker login -u ${INPUT_USERNAME} --password-stdin dock
 
 # Set Local Variables
 BASE_NAME="docker.pkg.github.com/${GITHUB_REPOSITORY}/${INPUT_IMAGE_NAME}"
-SHA_NAME="${BASE_NAME}:${shortSHA}"
+SHA_NAME="${BASE_NAME}:${IMAGE_TAG}"
 
 # Add Arguments For Caching
 BUILDPARAMS=""

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -34,7 +34,7 @@ fi
 
 if [[ -z "$INPUT_IMAGE_TAG" ]]; then
 	shortSHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
-elif
+else
 	shortSHA=$INPUT_IMAGE_TAG
 fi
 

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -32,6 +32,11 @@ if [[ -z "$INPUT_BUILD_CONTEXT" ]]; then
 	exit 1
 fi
 
+if [[ -z "$INPUT_IMAGE_TAG" ]]; then
+	shortSHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
+elif
+	shortSHA=$INPUT_IMAGE_TAG
+fi
 
 # The following environment variables will be provided by the environment automatically: GITHUB_REPOSITORY, GITHUB_SHA
 
@@ -39,7 +44,6 @@ fi
 echo ${INPUT_PASSWORD} | docker login -u ${INPUT_USERNAME} --password-stdin docker.pkg.github.com
 
 # Set Local Variables
-shortSHA=$(echo "${GITHUB_SHA}" | cut -c1-12)
 BASE_NAME="docker.pkg.github.com/${GITHUB_REPOSITORY}/${INPUT_IMAGE_NAME}"
 SHA_NAME="${BASE_NAME}:${shortSHA}"
 


### PR DESCRIPTION
I added the functionality to implicitly use Git Tags as additional Docker Tags. Means: If you commit a new Git Tag, an appropriate additional Docker Tag with the same name is going to be created as well.
I fixed a few typos and introduced a Github Workflow to get this action tested.

I already did an integration test by using this functionality here:
https://github.com/saubermacherag/docker-ansible-alpine

The big advantage I see is that you can comfortably draft a realease on Github which implicitly creates a GIT tag which will also become the docker tag.


Due to issue https://github.community/t5/GitHub-Actions/docker-pull-from-public-GitHub-Package-Registry-fail-with-quot/m-p/32782
which basically says, that Github Actions cannot rely on Docker Images on Github's Package Registry without authentication

I also added the DOCKERHUB_REPOSITORY option which allow to push the image to dockerhub instead of GPR.